### PR TITLE
fix(GenerateTree.cs) : 생성된 나무를 TreeGenerator의 자손으로 설정

### DIFF
--- a/Assets/JJW/Scene/CharacterTest1110.unity.meta
+++ b/Assets/JJW/Scene/CharacterTest1110.unity.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 <<<<<<<< HEAD:Assets/Scenes/MidBossTest.unity.meta
-guid: 0edba062a5df04144912df9fdc2117db
+guid: a97eaf7a7f6f30a4d8ae1b02c53b4d7c
 ========
 guid: bc68d52131d19394b886afe96eabfad8
 >>>>>>>> upstream/main:Assets/JJW/Scene/CharacterTest1110.unity.meta

--- a/Assets/KHJ/Scripts/Puzzle1/GenerateTree.cs
+++ b/Assets/KHJ/Scripts/Puzzle1/GenerateTree.cs
@@ -50,7 +50,7 @@ public class GenerateTree : MonoBehaviour
                 if (Random.value < treePlacementChance)
                 {
                     GameObject treePrefab = treePrefabs[Random.Range(0, treePrefabs.Length)];
-                    Instantiate(treePrefab, position, Quaternion.identity);
+                    Instantiate(treePrefab, position, Quaternion.identity,transform);
                 }
             }
         }

--- a/Assets/Scenes/MidBossTest.unity.meta
+++ b/Assets/Scenes/MidBossTest.unity.meta
@@ -1,6 +1,6 @@
 fileFormatVersion: 2
 <<<<<<<< HEAD:Assets/Scenes/MidBossTest.unity.meta
-guid: 0edba062a5df04144912df9fdc2117db
+guid: dad9543402c58c04385cee3a4007a4e1
 ========
 guid: bc68d52131d19394b886afe96eabfad8
 >>>>>>>> upstream/main:Assets/JJW/Scene/CharacterTest1110.unity.meta


### PR DESCRIPTION
closed #44 

### 설명
- 생성된 나무를 TreeGenerator의 자손으로 설정

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
