### PR TITLE
Refact/96

### DIFF
--- a/Assets/Art Resources/Cainos/Pixel Art Top Down - Basic/Patch - URP 2D Lit.unitypackage.meta
+++ b/Assets/Art Resources/Cainos/Pixel Art Top Down - Basic/Patch - URP 2D Lit.unitypackage.meta
@@ -1,7 +1,0 @@
-fileFormatVersion: 2
-guid: 6c42f65fc9eb82943a26f6d854764887
-DefaultImporter:
-  externalObjects: {}
-  userData: 
-  assetBundleName: 
-  assetBundleVariant: 

--- a/Assets/Scripts/Creature/Creature.cs
+++ b/Assets/Scripts/Creature/Creature.cs
@@ -105,15 +105,15 @@ public class Creature : MonoBehaviour
     }
     public void OnHit()
     {
-        StopAllCoroutines();
         StartCoroutine(OnHitCoroutine());
     }
 
     private IEnumerator OnHitCoroutine()
     {
+        State curState_ = curState;
         ChangeState(State.ONHIT);
-        yield return new WaitForSeconds(0.5f);
-        ChangeState(State.IDLE);
+        yield return null;
+        ChangeState(curState_);
     }
 }
 

--- a/Assets/Scripts/Creature/MidBoss/MidBoss.cs
+++ b/Assets/Scripts/Creature/MidBoss/MidBoss.cs
@@ -193,7 +193,7 @@ public class MidBoss : Boss
         int randomIndex;
         List<int> weightedPatterns = new List<int>();
 
-        // ����ġ�� �ݿ��Ͽ� ����Ʈ�� ������ �߰�
+        // ����ġ�� ���Ͽ� ����Ʈ�� ������ �߰�
         if (currentPhase == 1)
         {
             weightedPatterns.AddRange(Enumerable.Repeat(0, 5));


### PR DESCRIPTION
OnHit 매서드 수정

closed #96 

### 설명
- 이슈96 해결
  - Creature 클래스의 OnHit 매서드 수정했습니다.
  - 맞으면 모든 코루틴 멈추고 ONHIT 상태로 넘어갔다가 0.5초 쉬고 iDLE상태로 넘어왔는데
  - 진행 중이던 상태 저장 후 ONHIT로 넘어갔다가 다시 진행 중이던 상태로 돌아옵니다.
  - 대신 보스가 상시 슈퍼아머 상태임
### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
