### PR TITLE
Feature/275

### DIFF
--- a/Assets/Prefabs/InGameManager.prefab
+++ b/Assets/Prefabs/InGameManager.prefab
@@ -801,6 +801,7 @@ GameObject:
   - component: {fileID: 7892075988172800473}
   - component: {fileID: 1949057745670997371}
   - component: {fileID: 2925716727880741511}
+  - component: {fileID: 8458395038088947841}
   m_Layer: 5
   m_Name: InGameManager
   m_TagString: Untagged
@@ -1077,6 +1078,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: d4986372d9bc447e7b7995902c6f14ab, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &8458395038088947841
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3010824913889302522}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a996ea4f5902a419583690e6dac381c7, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1 &4086936266442970915

--- a/Assets/Prefabs/Map/Test.meta
+++ b/Assets/Prefabs/Map/Test.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: e208a9ee0e529442891b51f56b22a40e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Map/Test/Brick.prefab
+++ b/Assets/Prefabs/Map/Test/Brick.prefab
@@ -1,0 +1,166 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &4267905787534412233
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5311282634834096694}
+  - component: {fileID: 1154495350621198447}
+  - component: {fileID: 8570881917040693851}
+  - component: {fileID: 5838228844521286364}
+  - component: {fileID: 5959661308913663269}
+  m_Layer: 0
+  m_Name: Brick
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5311282634834096694
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4267905787534412233}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.18, y: -0.88, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1154495350621198447
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4267905787534412233}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: b33149c4b5e98414b90370dbc851b8c8, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  _prefab: {fileID: 0}
+  _uniqueId: 
+--- !u!212 &8570881917040693851
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4267905787534412233}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: -4986890610287934012, guid: 274d64617113287499ed1c4165d1d8f3,
+    type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
+--- !u!58 &5838228844521286364
+CircleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4267905787534412233}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  serializedVersion: 2
+  m_Radius: 0.3
+--- !u!50 &5959661308913663269
+Rigidbody2D:
+  serializedVersion: 4
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4267905787534412233}
+  m_BodyType: 0
+  m_Simulated: 1
+  m_UseFullKinematicContacts: 0
+  m_UseAutoMass: 0
+  m_Mass: 1
+  m_LinearDrag: 100
+  m_AngularDrag: 100
+  m_GravityScale: 0
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_Interpolate: 0
+  m_SleepingMode: 1
+  m_CollisionDetection: 0
+  m_Constraints: 4

--- a/Assets/Prefabs/Map/Test/Brick.prefab.meta
+++ b/Assets/Prefabs/Map/Test/Brick.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 103735b0e38d74797bcb57e79df16fa7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/SpringRemaster/SpringShadowForestScene.unity
+++ b/Assets/Scenes/SpringRemaster/SpringShadowForestScene.unity
@@ -20398,7 +20398,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   vfxRenderer: {fileID: 1248402846}
-  transforms: []
+  _transforms: []
 --- !u!1 &1372614476 stripped
 GameObject:
   m_CorrespondingSourceObject: {fileID: 266987102060594552, guid: 7daeed62427ff47e4a7612401d73d268,
@@ -20555,12 +20555,12 @@ PrefabInstance:
     - target: {fileID: 2490236768487297665, guid: 64f1ae9c03ebe9d4c9496b6f4942f313,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 69
+      value: 1.3
       objectReference: {fileID: 0}
     - target: {fileID: 2490236768487297665, guid: 64f1ae9c03ebe9d4c9496b6f4942f313,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -1.2
+      value: -1.36
       objectReference: {fileID: 0}
     - target: {fileID: 2490236768487297665, guid: 64f1ae9c03ebe9d4c9496b6f4942f313,
         type: 3}
@@ -31965,6 +31965,90 @@ Transform:
     type: 3}
   m_PrefabInstance: {fileID: 2143846489}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &3849885452210037320
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1154495350621198447, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: _prefab
+      value: 
+      objectReference: {fileID: 4267905787534412233, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+    - target: {fileID: 1154495350621198447, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: _uniqueId
+      value: brick
+      objectReference: {fileID: 0}
+    - target: {fileID: 4267905787534412233, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_Name
+      value: Brick
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.18
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -0.88
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5311282634834096694, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8570881917040693851, guid: 103735b0e38d74797bcb57e79df16fa7,
+        type: 3}
+      propertyPath: m_SortingOrder
+      value: 11
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 103735b0e38d74797bcb57e79df16fa7, type: 3}
 --- !u!1660057539 &9223372036854775807
 SceneRoots:
   m_ObjectHideFlags: 0
@@ -31983,3 +32067,4 @@ SceneRoots:
   - {fileID: 1784437195}
   - {fileID: 686416598}
   - {fileID: 1981575124}
+  - {fileID: 3849885452210037320}

--- a/Assets/Scripts/System/Event/Event/Data/SaveDataEvent.cs
+++ b/Assets/Scripts/System/Event/Event/Data/SaveDataEvent.cs
@@ -1,6 +1,8 @@
 using System.Collections;
+using System.Game.Object.Persisted;
 using System.Game.Quest.Component;
 using playerCharacter;
+using Unity.VisualScripting;
 using UnityEngine.SceneManagement;
 public class SaveDataEvent : Event
 {
@@ -64,6 +66,8 @@ public class LoadDataEvent : Event
 
         SceneManager.LoadScene(playerData.sceneName);
         DataManager.Instance.LoadPlayerData();
+        
+        PersistedGameObjectManager.Instance.SetPersistedGameObjects(DataManager.Instance.LoadSection<PersistedGameObjectDatas>(PersistedGameObjectManager.PERSISTED_DATA_FILE));
         yield return null;
     }
 }

--- a/Assets/Scripts/System/Event/Event/Data/SaveDataEvent.cs
+++ b/Assets/Scripts/System/Event/Event/Data/SaveDataEvent.cs
@@ -31,6 +31,8 @@ public class SaveDataEvent : Event
         DataManager.Instance.SaveSection(runeData, "RuneData");
         
         ConditionManager.Instance.Save();
+        
+        PersistedGameObjectManager.Instance.Save();
 
         yield return null;
     }

--- a/Assets/Scripts/System/Game/Object/Persisted.meta
+++ b/Assets/Scripts/System/Game/Object/Persisted.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bc260c4eec3f04cc2a4161a76537f684
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/System/Game/Object/Persisted/IPersistedComponent.cs
+++ b/Assets/Scripts/System/Game/Object/Persisted/IPersistedComponent.cs
@@ -1,0 +1,10 @@
+namespace System.Game.Object.Persisted
+{
+    [Serializable]
+    public abstract class ComponentData {}
+    public interface IPersistedComponent
+    {
+        public ComponentData Save();
+        public void Load(ComponentData data);
+    }
+}

--- a/Assets/Scripts/System/Game/Object/Persisted/IPersistedComponent.cs.meta
+++ b/Assets/Scripts/System/Game/Object/Persisted/IPersistedComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: cb88f69e33601471eb1bef683ee09cb8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObject.cs
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObject.cs
@@ -1,37 +1,63 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace System.Game.Object.Persisted
 {
+    [Serializable]
+    public struct PersistedGameObjectData
+    {
+        public string uniqueId;
+        public GameObject prefab;
+        public bool isActive;
+        public string sceneName;
+        public Vector3 position;
+        public List<ComponentData> componentDatas;
+
+        public PersistedGameObjectData(string uniqueId, GameObject prefab, bool isActive, string sceneName, Vector3 position, List<ComponentData> componentDatas)
+        {
+            this.uniqueId = uniqueId; this.prefab = prefab; this.isActive = isActive; this.sceneName = sceneName; this.position = position; this.componentDatas = componentDatas;
+        }
+    }
+    
     public class PersistedGameObject : MonoBehaviour
     {
         [SerializeField] [Tooltip("Reference It's Own Prefab")] private GameObject _prefab;
         [SerializeField] private string _uniqueId;
+        public string UniqueId => _uniqueId;
         
-        private List<ComponentData> _componentData = new();
+        private List<ComponentData> _componentDatas = new();
         
-        public (string uniqueId, GameObject prefab, Vector3 position, List<ComponentData> componentData) Save()
+        public PersistedGameObjectData Save()
         {
             SaveComponents();
-            return (_uniqueId, _prefab, transform.position, _componentData);
+            return new PersistedGameObjectData(
+                _uniqueId, 
+                _prefab, 
+                gameObject.activeSelf, 
+                SceneManager.GetActiveScene().name, 
+                transform.position, 
+                _componentDatas
+                );
         }
         
-        public void Load((string uniqueId, GameObject prefab, Vector3 position, List<ComponentData> componentData) data)
+        public void Load(PersistedGameObjectData data)
         {
             _uniqueId = data.uniqueId;
             _prefab = data.prefab;
             transform.position = data.position;
-            _componentData = data.componentData;
+            _componentDatas = data.componentDatas;
             LoadComponents();
+            gameObject.SetActive(data.isActive);
         }
         
         private void SaveComponents()
         {
-            _componentData.Clear();
+            _componentDatas.Clear();
             var components = GetComponentsInChildren<IPersistedComponent>();
             foreach (IPersistedComponent component in components)
             {
-                _componentData.Add(component.Save());
+                _componentDatas.Add(component.Save());
             }
         }
         
@@ -41,7 +67,7 @@ namespace System.Game.Object.Persisted
             var components = GetComponentsInChildren<IPersistedComponent>();
             foreach (var component in components)
             {
-                component.Load(_componentData[i]);
+                component.Load(_componentDatas[i]);
                 i++;
             }
         }

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObject.cs
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObject.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace System.Game.Object.Persisted
+{
+    public class PersistedGameObject : MonoBehaviour
+    {
+        [SerializeField] [Tooltip("Reference It's Own Prefab")] private GameObject _prefab;
+        [SerializeField] private string _uniqueId;
+        
+        private List<ComponentData> _componentData = new();
+        
+        public (string uniqueId, GameObject prefab, Vector3 position, List<ComponentData> componentData) Save()
+        {
+            SaveComponents();
+            return (_uniqueId, _prefab, transform.position, _componentData);
+        }
+        
+        public void Load((string uniqueId, GameObject prefab, Vector3 position, List<ComponentData> componentData) data)
+        {
+            _uniqueId = data.uniqueId;
+            _prefab = data.prefab;
+            transform.position = data.position;
+            _componentData = data.componentData;
+            LoadComponents();
+        }
+        
+        private void SaveComponents()
+        {
+            _componentData.Clear();
+            var components = GetComponentsInChildren<IPersistedComponent>();
+            foreach (IPersistedComponent component in components)
+            {
+                _componentData.Add(component.Save());
+            }
+        }
+        
+        private void LoadComponents()
+        {
+            int i = 0;
+            var components = GetComponentsInChildren<IPersistedComponent>();
+            foreach (var component in components)
+            {
+                component.Load(_componentData[i]);
+                i++;
+            }
+        }
+    }
+}

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObject.cs.meta
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObject.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b33149c4b5e98414b90370dbc851b8c8
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
@@ -8,11 +8,11 @@ namespace System.Game.Object.Persisted
     [Serializable]
     public class PersistedGameObjectDatas
     {
-        [SerializeField] private List<(string uniqueId, PersistedGameObjectData data)> _datas = new();
+        [SerializeField] private List<PersistedGameObjectData> _datas = new();
 
         public PersistedGameObjectDatas(Dictionary<string, PersistedGameObjectData> datas)
         {
-            _datas = datas.Select(kv => (kv.Key, kv.Value)).ToList();
+            _datas = datas.Values.ToList();
         }
 
         public PersistedGameObjectDatas()
@@ -22,7 +22,7 @@ namespace System.Game.Object.Persisted
 
         public static implicit operator Dictionary<string, PersistedGameObjectData>(PersistedGameObjectDatas datas)
         {
-            return datas._datas.ToDictionary(kv => kv.uniqueId, kv => kv.data);
+            return datas._datas.ToDictionary(kv => kv.uniqueId, kv => kv);
         }
     }
     
@@ -37,6 +37,8 @@ namespace System.Game.Object.Persisted
         public void SetPersistedGameObjects(PersistedGameObjectDatas persistedGameObjects)
         {
             _persistedGameObjects = persistedGameObjects;
+            ScanPersistedGameObjects();
+            PlacePersistedGameObjects();
         }
         
         private void OnSceneLoaded(Scene arg0, LoadSceneMode arg1)

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace System.Game.Object.Persisted
+{
+    public class PersistedGameObjectManager : SingletonObject<PersistedGameObjectManager>
+    {
+        private Dictionary<string, (GameObject prefab, Vector3 position, List<ComponentData> componentDatas)> _persistedGameObjects = new();
+        
+        public void SavePersistedGameObject(PersistedGameObject persistedGameObject, Vector3 position)
+        {
+            var datas = persistedGameObject.Save();
+            _persistedGameObjects[datas.uniqueId] = (datas.prefab, position, datas.componentData);
+        }
+        
+    }
+}

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
@@ -1,13 +1,44 @@
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.SceneManagement;
 
 namespace System.Game.Object.Persisted
 {
+    [Serializable]
+    public class PersistedGameObjectDatas
+    {
+        [SerializeField] private List<(string uniqueId, PersistedGameObjectData data)> _datas = new();
+
+        public PersistedGameObjectDatas(Dictionary<string, PersistedGameObjectData> datas)
+        {
+            _datas = datas.Select(kv => (kv.Key, kv.Value)).ToList();
+        }
+
+        public PersistedGameObjectDatas()
+        {
+            throw new NotImplementedException();
+        }
+
+        public static implicit operator Dictionary<string, PersistedGameObjectData>(PersistedGameObjectDatas datas)
+        {
+            return datas._datas.ToDictionary(kv => kv.uniqueId, kv => kv.data);
+        }
+    }
+    
     public class PersistedGameObjectManager : SingletonObject<PersistedGameObjectManager>
     {
         private Dictionary<string, PersistedGameObjectData> _persistedGameObjects = new();
-
+        public static string PERSISTED_DATA_FILE = "persistedGameObjects";
+        public void Save()
+        {
+            DataManager.Instance.SaveSection(new PersistedGameObjectDatas(_persistedGameObjects), PERSISTED_DATA_FILE);
+        }
+        public void SetPersistedGameObjects(PersistedGameObjectDatas persistedGameObjects)
+        {
+            _persistedGameObjects = persistedGameObjects;
+        }
+        
         private void OnSceneLoaded(Scene arg0, LoadSceneMode arg1)
         {
             ScanPersistedGameObjects();

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
@@ -1,17 +1,87 @@
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.SceneManagement;
 
 namespace System.Game.Object.Persisted
 {
     public class PersistedGameObjectManager : SingletonObject<PersistedGameObjectManager>
     {
-        private Dictionary<string, (GameObject prefab, Vector3 position, List<ComponentData> componentDatas)> _persistedGameObjects = new();
+        private Dictionary<string, PersistedGameObjectData> _persistedGameObjects = new();
         
-        public void SavePersistedGameObject(PersistedGameObject persistedGameObject, Vector3 position)
+        private void OnSceneLoaded(Scene arg0, LoadSceneMode arg1)
         {
-            var datas = persistedGameObject.Save();
-            _persistedGameObjects[datas.uniqueId] = (datas.prefab, position, datas.componentData);
+            ScanPersistedGameObjects();
+            PlacePersistedGameObjects();
+        }
+
+        private void ScanPersistedGameObjects()
+        {
+            PersistedGameObject[] objects = FindObjectsByType<PersistedGameObject>(FindObjectsSortMode.None);
+            foreach (PersistedGameObject persistedGameObject in objects)
+            {
+                if (_persistedGameObjects.ContainsKey(persistedGameObject.UniqueId))
+                { // this GameObject's Data is already saved
+                    ApplyDataToPersistedGameObject(persistedGameObject, SceneManager.GetActiveScene());
+                }
+                else
+                { // this GameObject is not saved yet
+                    SavePersistedGameObject(persistedGameObject);
+                }
+            }
+        }
+        private void PlacePersistedGameObjects()
+        {
+            HashSet<string> existingObjectIds = new HashSet<string>();
+            foreach (var obj in FindObjectsByType<PersistedGameObject>(FindObjectsSortMode.None))
+            {
+                existingObjectIds.Add(obj.UniqueId);
+            }
+
+            foreach (var data in _persistedGameObjects.Values)
+            {
+                if (SceneManager.GetActiveScene().name.Equals(data.sceneName))
+                {
+                    if (existingObjectIds.Contains(data.uniqueId))
+                    {
+                        continue;
+                    }
+
+                    GameObject go = Instantiate(data.prefab, data.position, Quaternion.identity);
+                    PersistedGameObject persistedGameObject = go.GetComponent<PersistedGameObject>();
+                    persistedGameObject.Load(data);
+                }
+            }
         }
         
+        private void Start()
+        {
+            ScanPersistedGameObjects();
+            PlacePersistedGameObjects();
+            SceneManager.sceneLoaded += OnSceneLoaded;
+        }
+        private void OnDestroy()
+        {
+            SceneManager.sceneLoaded -= OnSceneLoaded;
+        }
+
+        private void ApplyDataToPersistedGameObject(PersistedGameObject persistedGameObject, Scene scene)
+        {
+            var data = _persistedGameObjects[persistedGameObject.UniqueId];
+            if (scene.name.Equals(data.sceneName))
+            {
+                persistedGameObject.Load(data);
+            }
+            else
+            {
+                Destroy(persistedGameObject.gameObject);
+            }
+        }
+        
+        private void SavePersistedGameObject(PersistedGameObject persistedGameObject)
+        {
+            var datas = persistedGameObject.Save();
+            _persistedGameObjects[datas.uniqueId] = datas;
+        }
+       
     }
 }

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs
@@ -69,13 +69,8 @@ namespace System.Game.Object.Persisted
 
             foreach (var data in _persistedGameObjects.Values)
             {
-                if (SceneManager.GetActiveScene().name.Equals(data.sceneName))
+                if (SceneManager.GetActiveScene().name.Equals(data.sceneName) && !existingObjectIds.Contains(data.uniqueId))
                 {
-                    if (existingObjectIds.Contains(data.uniqueId))
-                    {
-                        continue;
-                    }
-
                     GameObject go = Instantiate(data.prefab, data.position, Quaternion.identity);
                     PersistedGameObject persistedGameObject = go.GetComponent<PersistedGameObject>();
                     print("Placing PersistedGameObject: " + persistedGameObject.UniqueId);

--- a/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs.meta
+++ b/Assets/Scripts/System/Game/Object/Persisted/PersistedGameObjectManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a996ea4f5902a419583690e6dac381c7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/System/Game/Portal/PortalManager.cs
+++ b/Assets/Scripts/System/Game/Portal/PortalManager.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
@@ -8,6 +9,8 @@ public class PortalManager : SingletonObject<PortalManager>
     [SerializeField] SceneDataList sceneDataList;
     [SerializeField] PortalDataList portalDataList;
 
+    public static event Action<Scene> sceneUnloading;
+    
     private void Start()
     {
         DontDestroyOnLoad(this);
@@ -19,8 +22,12 @@ public class PortalManager : SingletonObject<PortalManager>
         PortalData portalData = portalDataList.GetPortalDataByID(portalID);
         SceneData sceneData = sceneDataList.GetSceneDataByID(portalData.sceneID);
         if (!sceneData.sceneName.Equals(SceneManager.GetActiveScene().name))
+        {
+            sceneUnloading?.Invoke(SceneManager.GetActiveScene());
             SceneManager.LoadScene(sceneData.sceneName);
+        }
         playerCharacter.PlayerCharacter.Instance.transform.position = portalData.destination;
         StartCoroutine(EffectManager.Instance.FadeIn());
     }
+    
 }


### PR DESCRIPTION
closed #275

### 설명
- GameObject가 씬이 전환 되거나 게임을 껐다가 켜도 위치나 정보를 유지하도록 하는 시스템 구현
- PersistedGameObject를 componet로 단다.
- Component 중에도 저장해야할 것이 있다면, IPersistedComponent를 달고 저장, 로드의 이벤트를 정의한다.

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
