### PR TITLE
Feat/408

### DIFF
--- a/Assets/Resources/Effects/Fog.vfx
+++ b/Assets/Resources/Effects/Fog.vfx
@@ -347,7 +347,7 @@ MonoBehaviour:
       m_Type:
         m_SerializableType: UnityEditor.VFX.AABox, Unity.VisualEffectGraph.Editor,
           Version=0.0.0.0, Culture=neutral, PublicKeyToken=null
-      m_SerializableObject: '{"center":{"x":-7.268699645996094,"y":-0.8398504257202148,"z":-0.018482446670532228},"size":{"x":26.040130615234376,"y":56.97072982788086,"z":3.0607447624206545}}'
+      m_SerializableObject: '{"center":{"x":-7.268699645996094,"y":-0.8398504257202148,"z":-0.018482446670532228},"size":{"x":100.0,"y":100.0,"z":100.0}}'
     m_Space: 0
   m_Property:
     name: bounds
@@ -2644,12 +2644,11 @@ MonoBehaviour:
   - {fileID: 8926484042661614656}
   - {fileID: 8926484042661614657}
   - {fileID: 8926484042661614658}
-  - {fileID: 8926484042661614683}
   m_OutputSlots: []
   m_Disabled: 0
   m_ActivationSlot: {fileID: 8926484042661614659}
   mode: 0
-  radiusMode: 2
+  radiusMode: 0
   roughSurface: 0
 --- !u!114 &8926484042661614641
 MonoBehaviour:
@@ -4094,40 +4093,6 @@ MonoBehaviour:
       m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
         PublicKeyToken=b77a5c561934e089
   m_Direction: 1
-  m_LinkedSlots: []
---- !u!114 &8926484042661614683
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 0}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: f780aa281814f9842a7c076d436932e7, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  m_UIIgnoredErrors: []
-  m_Parent: {fileID: 0}
-  m_Children: []
-  m_UIPosition: {x: 0, y: 0}
-  m_UICollapsed: 1
-  m_UISuperCollapsed: 0
-  m_MasterSlot: {fileID: 8926484042661614683}
-  m_MasterData:
-    m_Owner: {fileID: 8926484042661614640}
-    m_Value:
-      m_Type:
-        m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-          PublicKeyToken=b77a5c561934e089
-      m_SerializableObject: 3.8
-    m_Space: 2147483647
-  m_Property:
-    name: radius
-    m_serializedType:
-      m_SerializableType: System.Single, mscorlib, Version=4.0.0.0, Culture=neutral,
-        PublicKeyToken=b77a5c561934e089
-  m_Direction: 0
   m_LinkedSlots: []
 --- !u!114 &8926484042661614684
 MonoBehaviour:

--- a/Assets/Resources/Prefabs/Creature/Boss/NagaRogue/RogueMinion_Story.prefab
+++ b/Assets/Resources/Prefabs/Creature/Boss/NagaRogue/RogueMinion_Story.prefab
@@ -1,235 +1,5 @@
 %YAML 1.1
 %TAG !u! tag:unity3d.com,2011:
---- !u!1 &24824773601625811
-GameObject:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  serializedVersion: 6
-  m_Component:
-  - component: {fileID: 5678845240593367790}
-  - component: {fileID: 5977871699253440304}
-  - component: {fileID: 6834810348462202315}
-  - component: {fileID: 5773573159340300846}
-  - component: {fileID: 5845419958948342550}
-  - component: {fileID: 6230906477228946598}
-  - component: {fileID: 724075008157394094}
-  m_Layer: 0
-  m_Name: RogueMinion_Story
-  m_TagString: Boss
-  m_Icon: {fileID: 0}
-  m_NavMeshLayer: 0
-  m_StaticEditorFlags: 0
-  m_IsActive: 1
---- !u!4 &5678845240593367790
-Transform:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24824773601625811}
-  serializedVersion: 2
-  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.5, y: 0.2, z: 0}
-  m_LocalScale: {x: 0.9, y: 0.9, z: 1}
-  m_ConstrainProportionsScale: 0
-  m_Children: []
-  m_Father: {fileID: 2068315447394565575}
-  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!212 &5977871699253440304
-SpriteRenderer:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24824773601625811}
-  m_Enabled: 1
-  m_CastShadows: 0
-  m_ReceiveShadows: 0
-  m_DynamicOccludee: 1
-  m_StaticShadowCaster: 0
-  m_MotionVectors: 1
-  m_LightProbeUsage: 1
-  m_ReflectionProbeUsage: 1
-  m_RayTracingMode: 0
-  m_RayTraceProcedural: 0
-  m_RenderingLayerMask: 1
-  m_RendererPriority: 0
-  m_Materials:
-  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
-  m_StaticBatchInfo:
-    firstSubMesh: 0
-    subMeshCount: 0
-  m_StaticBatchRoot: {fileID: 0}
-  m_ProbeAnchor: {fileID: 0}
-  m_LightProbeVolumeOverride: {fileID: 0}
-  m_ScaleInLightmap: 1
-  m_ReceiveGI: 1
-  m_PreserveUVs: 0
-  m_IgnoreNormalsForChartDetection: 0
-  m_ImportantGI: 0
-  m_StitchLightmapSeams: 1
-  m_SelectedEditorRenderState: 0
-  m_MinimumChartSize: 4
-  m_AutoUVMaxDistance: 0.5
-  m_AutoUVMaxAngle: 89
-  m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
-  m_SortingOrder: 10
-  m_Sprite: {fileID: 21300000, guid: b4e01c76bdabec048935ab713519aa46, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
-  m_FlipX: 0
-  m_FlipY: 0
-  m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
-  m_AdaptiveModeThreshold: 0.5
-  m_SpriteTileMode: 0
-  m_WasSpriteAssigned: 1
-  m_MaskInteraction: 0
-  m_SpriteSortPoint: 0
---- !u!50 &6834810348462202315
-Rigidbody2D:
-  serializedVersion: 4
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24824773601625811}
-  m_BodyType: 1
-  m_Simulated: 1
-  m_UseFullKinematicContacts: 0
-  m_UseAutoMass: 0
-  m_Mass: 10000
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
-  m_GravityScale: 0
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_Interpolate: 0
-  m_SleepingMode: 1
-  m_CollisionDetection: 1
-  m_Constraints: 4
---- !u!61 &5773573159340300846
-BoxCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24824773601625811}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 1
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  m_SpriteTilingProperty:
-    border: {x: 0, y: 0, z: 0, w: 0}
-    pivot: {x: 0.5, y: 0.5}
-    oldSize: {x: 1.83, y: 2.02}
-    newSize: {x: 1, y: 1}
-    adaptiveTilingThreshold: 0.5
-    drawMode: 0
-    adaptiveTiling: 0
-  m_AutoTiling: 0
-  serializedVersion: 2
-  m_Size: {x: 1, y: 1}
-  m_EdgeRadius: 0
---- !u!95 &5845419958948342550
-Animator:
-  serializedVersion: 5
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24824773601625811}
-  m_Enabled: 0
-  m_Avatar: {fileID: 0}
-  m_Controller: {fileID: 9100000, guid: 2423237b3a72bed4b9b463bced41800e, type: 2}
-  m_CullingMode: 0
-  m_UpdateMode: 0
-  m_ApplyRootMotion: 0
-  m_LinearVelocityBlending: 0
-  m_StabilizeFeet: 0
-  m_WarningMessage: 
-  m_HasTransformHierarchy: 1
-  m_AllowConstantClipSamplingOptimization: 1
-  m_KeepAnimatorStateOnDisable: 0
-  m_WriteDefaultValuesOnDisable: 0
---- !u!58 &6230906477228946598
-CircleCollider2D:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24824773601625811}
-  m_Enabled: 1
-  m_Density: 1
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_ForceSendLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ForceReceiveLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_ContactCaptureLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_CallbackLayers:
-    serializedVersion: 2
-    m_Bits: 4294967295
-  m_IsTrigger: 0
-  m_UsedByEffector: 0
-  m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
-  m_Radius: 0.3
---- !u!114 &724075008157394094
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 24824773601625811}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 77d66079f6584a2b8638783f028adf4f, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  _materialDatas: {fileID: 11400000, guid: b83ab9d50893f408cbb45301ce80bf11, type: 2}
 --- !u!1 &749068473109553278
 GameObject:
   m_ObjectHideFlags: 0
@@ -246,7 +16,7 @@ GameObject:
   - component: {fileID: 4305851360897111492}
   - component: {fileID: 1804139627666161557}
   m_Layer: 0
-  m_Name: RogueMinion_Story (1)
+  m_Name: RogueMinion_Story (2)
   m_TagString: Boss
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -261,7 +31,7 @@ Transform:
   m_GameObject: {fileID: 749068473109553278}
   serializedVersion: 2
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 1.5, y: 0.2, z: 0}
+  m_LocalPosition: {x: 1.5, y: -0.1, z: 0}
   m_LocalScale: {x: 0.9, y: 0.9, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -460,6 +230,90 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _materialDatas: {fileID: 11400000, guid: b83ab9d50893f408cbb45301ce80bf11, type: 2}
+--- !u!1 &1198312868440469368
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3812106746491368514}
+  - component: {fileID: 7808856216022500358}
+  m_Layer: 0
+  m_Name: RogueMinion_Story (1)
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3812106746491368514
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1198312868440469368}
+  serializedVersion: 2
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: -2.21, y: -0.15, z: 0}
+  m_LocalScale: {x: 0.82, y: 0.82, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 2068315447394565575}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &7808856216022500358
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1198312868440469368}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: a97c105638bdf8b4a8650670310a4cd3, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 10
+  m_Sprite: {fileID: -1758841345, guid: 7206bb5013a9c4d53a667edd8ab92fbd, type: 3}
+  m_Color: {r: 0.2754717, g: 0.2754717, b: 0.2754717, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1.92, y: 1.92}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0
 --- !u!1 &4319988163936315400
 GameObject:
   m_ObjectHideFlags: 0
@@ -495,7 +349,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children:
-  - {fileID: 5678845240593367790}
+  - {fileID: 3812106746491368514}
   - {fileID: 5536838062589922899}
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Scenes/Alpha Version/a0.0.1-1/SpringBeach.unity
+++ b/Assets/Scenes/Alpha Version/a0.0.1-1/SpringBeach.unity
@@ -980,6 +980,21 @@ PrefabInstance:
       propertyPath: m_CompositePaths.m_Paths.Array.size
       value: 50
       objectReference: {fileID: 0}
+    - target: {fileID: 4627179773555251332, guid: fec9eb766a82244aa97ec572fbfe0fa8,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -2.7800002
+      objectReference: {fileID: 0}
+    - target: {fileID: 4627179773555251332, guid: fec9eb766a82244aa97ec572fbfe0fa8,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.00000011920929
+      objectReference: {fileID: 0}
+    - target: {fileID: 4627179773555251332, guid: fec9eb766a82244aa97ec572fbfe0fa8,
+        type: 3}
+      propertyPath: m_LocalPosition.z
+      value: -10
+      objectReference: {fileID: 0}
     - target: {fileID: 4703269627896603617, guid: fec9eb766a82244aa97ec572fbfe0fa8,
         type: 3}
       propertyPath: m_Points.Array.data[5].y
@@ -1449,17 +1464,17 @@ PrefabInstance:
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 3.0800002
+      value: -0.00000023841858
       objectReference: {fileID: 0}
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -0.10000024
+      value: 0.00000011920929
       objectReference: {fileID: 0}
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: -10.001161
+      value: -10
       objectReference: {fileID: 0}
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
@@ -1496,6 +1511,11 @@ PrefabInstance:
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 5122920374545422110, guid: c2f3182f131863545b899e8b19921037,
+        type: 3}
+      propertyPath: orthographic size
+      value: 3.6
+      objectReference: {fileID: 0}
     - target: {fileID: 5820504544349565276, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
       propertyPath: m_Name
@@ -1521,9 +1541,44 @@ PrefabInstance:
       objectReference: {fileID: 861508529}
     - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
         type: 3}
+      propertyPath: cameraSize1
+      value: 1.75
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraSize3
+      value: 7
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
       propertyPath: targetSlime
       value: 
       objectReference: {fileID: 1767817512}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraSpeed1
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraSpeed2
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraSpeed3
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraSpeed1_2
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraDuration3
+      value: 3
+      objectReference: {fileID: 0}
     - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
         type: 3}
       propertyPath: cameraDestination.x
@@ -1536,8 +1591,38 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
         type: 3}
+      propertyPath: cameraDestination1.x
+      value: -6
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraDestination1.z
+      value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraDestination3.x
+      value: 15
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraDestination3.y
+      value: 0.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraDestination3.z
+      value: -10
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
       propertyPath: afterScript.Array.size
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
+        type: 3}
+      propertyPath: cameraDestination1_2.z
+      value: -10
       objectReference: {fileID: 0}
     - target: {fileID: 2225460214615197347, guid: 30055aca067ec91458d59a057edc5762,
         type: 3}

--- a/Assets/Scenes/Alpha Version/a0.0.1-1/SpringGolemTemple.unity
+++ b/Assets/Scenes/Alpha Version/a0.0.1-1/SpringGolemTemple.unity
@@ -422,12 +422,12 @@ PrefabInstance:
     - target: {fileID: 2490236768487297665, guid: 64f1ae9c03ebe9d4c9496b6f4942f313,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 29.35
+      value: 29.03
       objectReference: {fileID: 0}
     - target: {fileID: 2490236768487297665, guid: 64f1ae9c03ebe9d4c9496b6f4942f313,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: -14.04
+      value: -3.42
       objectReference: {fileID: 0}
     - target: {fileID: 2490236768487297665, guid: 64f1ae9c03ebe9d4c9496b6f4942f313,
         type: 3}
@@ -8953,6 +8953,16 @@ PrefabInstance:
         type: 3}
       propertyPath: m_TileColorArray.Array.data[8].m_Data.r
       value: 0.7454688
+      objectReference: {fileID: 0}
+    - target: {fileID: 4563320288366550796, guid: e7e65a642d45e46ba8e8fc6f26e7d8e3,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 62.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 4563320288366550796, guid: e7e65a642d45e46ba8e8fc6f26e7d8e3,
+        type: 3}
+      propertyPath: m_LocalPosition.y
+      value: -11.6
       objectReference: {fileID: 0}
     - target: {fileID: 4932231612225608373, guid: e7e65a642d45e46ba8e8fc6f26e7d8e3,
         type: 3}
@@ -73223,12 +73233,12 @@ PrefabInstance:
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: -32.7
+      value: 29.3
       objectReference: {fileID: 0}
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
       propertyPath: m_LocalPosition.y
-      value: 6.8999996
+      value: -4.6000004
       objectReference: {fileID: 0}
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}

--- a/Assets/Scenes/Alpha Version/a0.0.1-1/SpringShadowIsland.unity
+++ b/Assets/Scenes/Alpha Version/a0.0.1-1/SpringShadowIsland.unity
@@ -400,6 +400,11 @@ PrefabInstance:
       propertyPath: m_Name
       value: Fog
       objectReference: {fileID: 0}
+    - target: {fileID: 2029004156272827827, guid: 3da75c5d25dd4c548b8998a4377811a2,
+        type: 3}
+      propertyPath: m_AllowInstancing
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 3516124982362296041, guid: 3da75c5d25dd4c548b8998a4377811a2,
         type: 3}
       propertyPath: m_SortingOrder
@@ -830,6 +835,8 @@ MonoBehaviour:
   shadow: {fileID: 1230071925}
   cameraDestination: {x: 70.6, y: -70.6, z: -10}
   cameraSpeed: 3
+  cameraSize: 7
+  cameraDuration: 3
   beforeScript:
   - {fileID: 11400000, guid: 215ce32ee8a4b40b6ac209a28b1f5a01, type: 2}
 --- !u!1 &1230071924
@@ -1265,6 +1272,16 @@ PrefabInstance:
       propertyPath: m_Name
       value: Map
       objectReference: {fileID: 0}
+    - target: {fileID: 4857733742662607138, guid: dcf3df2fbbb744b4db4cc3a6dec57cef,
+        type: 3}
+      propertyPath: m_Lens.OrthographicSize
+      value: 2.6
+      objectReference: {fileID: 0}
+    - target: {fileID: 6589789300961109404, guid: dcf3df2fbbb744b4db4cc3a6dec57cef,
+        type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 43.91
+      objectReference: {fileID: 0}
     m_RemovedComponents: []
     m_RemovedGameObjects: []
     m_AddedGameObjects: []
@@ -1399,7 +1416,7 @@ Transform:
   m_GameObject: {fileID: 1410551043}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 45.43, y: -70.6, z: 0}
+  m_LocalPosition: {x: 52.31, y: -70.6, z: 0}
   m_LocalScale: {x: -1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1443,7 +1460,7 @@ Transform:
   m_GameObject: {fileID: 1537090297}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 64.95499, y: -68.98729, z: 0.094781056}
+  m_LocalPosition: {x: 64.95499, y: -68.98729, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1462,6 +1479,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   _shadow: {fileID: 1410551051}
+  cameraSize1: 2.6
+  cameraDuration1: 0
+  cameraDestination1: {x: 43.91, y: -70.6, z: -10}
+  cameraSpeed1: 0
+  playerDestination1: {x: 47.42, y: -70.6, z: 0}
+  playerSpeed1: 2
+  cameraDestination2: {x: 51, y: -70.6, z: -10}
+  cameraSpeed2: 2
+  shadowDestination2: {x: 61.5, y: -70.6, z: 0}
+  shadowSpeed2: 3
 --- !u!1001 &1580948003
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1473,7 +1500,7 @@ PrefabInstance:
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 49.9
+      value: 43.91
       objectReference: {fileID: 0}
     - target: {fileID: 208246280978884676, guid: c2f3182f131863545b899e8b19921037,
         type: 3}
@@ -1519,6 +1546,11 @@ PrefabInstance:
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
       value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5122920374545422110, guid: c2f3182f131863545b899e8b19921037,
+        type: 3}
+      propertyPath: orthographic size
+      value: 2.6
       objectReference: {fileID: 0}
     - target: {fileID: 5820504544349565276, guid: c2f3182f131863545b899e8b19921037,
         type: 3}

--- a/Assets/Scenes/Summer/NagaRogueScene.unity
+++ b/Assets/Scenes/Summer/NagaRogueScene.unity
@@ -77967,9 +77967,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8769dc8b41fb1f0438bc5799f57dcf2a, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  playerDestination: {x: 29, y: 4, z: 0}
+  playerDestination: {x: 29, y: 8, z: 0}
   playerMoveSpeed: 2
-  cameraDestination: {x: 35, y: 8.5, z: -10}
+  cameraDestination: {x: 35, y: 9.2, z: -10}
   minionObject: {fileID: 4319988163936315400, guid: 952b6aaefa2d64d44a63e87a7b918316,
     type: 3}
   cameraSpeed: 3
@@ -78021,7 +78021,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   nagaRogue: {fileID: 8923030510415073920}
-  playerDestination: {x: 29, y: 9, z: 0}
+  playerDestination: {x: 29, y: 11, z: 0}
   playerMoveSpeed: 2
   wall: {fileID: 516904775}
   cameraDestination: {x: 0, y: 0, z: 0}
@@ -78248,7 +78248,7 @@ Transform:
   m_GameObject: {fileID: 4311090451529734521}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 29.13, y: 12.51, z: 0}
+  m_LocalPosition: {x: 29.12, y: 14.83, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []

--- a/Assets/Scripts/GyeMong/EventSystem/Controller/EffectManager.cs
+++ b/Assets/Scripts/GyeMong/EventSystem/Controller/EffectManager.cs
@@ -34,26 +34,26 @@ namespace GyeMong.EventSystem.Controller
         /// The screen is getting Ligther
         /// </summary>
         /// <returns>return IEnumerator</returns>
-        public IEnumerator FadeIn()
+        public IEnumerator FadeIn(float duration = 0.5f)
         {
-            return Fade(black, 0);
+            return Fade(black, 0, duration);
         }
 
         /// <summary>
         /// The screen is getting darker
         /// </summary>
         /// /// <returns>return IEnumerator</returns>
-        public IEnumerator FadeOut()
+        public IEnumerator FadeOut(float duration = 0.5f)
         {
-            return Fade(black, 1);
+            return Fade(black, 1, duration);
         }
 
-        public IEnumerator FadeInFirst()
+        public IEnumerator FadeInFirst(float duration = 0.5f)
         {
             Color color = black.color;
             color.a = 1;
             black.color = color;
-            return Fade(black, 0);
+            return Fade(black, 0, duration);
         }
 
         public IEnumerator ChangeToBlackScreen()
@@ -65,7 +65,7 @@ namespace GyeMong.EventSystem.Controller
             yield return null;
         }
 
-        private IEnumerator Fade(RawImage image, float targetAlpha, float duration = 0.5f)
+        private IEnumerator Fade(RawImage image, float targetAlpha, float duration)
         {
             Color color = image.color;
             float startAlpha = color.a;

--- a/Assets/Scripts/GyeMong/EventSystem/Event/CinematicEvent/CameraEvents.cs
+++ b/Assets/Scripts/GyeMong/EventSystem/Event/CinematicEvent/CameraEvents.cs
@@ -9,6 +9,8 @@ namespace GyeMong.EventSystem.Event.CinematicEvent
     {
         [SerializeField] private Vector3 destination;
         [SerializeField] private float speed;
+        public void SetDestination(Vector3 value) => destination = value;
+        public void SetSpeed(float value) => speed = value;
         public override IEnumerator Execute(EventObject eventObject = null)
         {
             return SceneContext.CameraManager.CameraMove(destination, speed);

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Mob/StateMachineMob/Boss/Summer/NagaRogue/SummerSceneOpeningEvent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Mob/StateMachineMob/Boss/Summer/NagaRogue/SummerSceneOpeningEvent.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using DG.Tweening;
 using GyeMong.EventSystem.Event;
 using GyeMong.EventSystem.Event.Chat;
 using GyeMong.EventSystem.Event.CinematicEvent;
@@ -38,6 +39,7 @@ namespace GyeMong.GameSystem.Creature.Mob.StateMachineMob.Boss.Summer.NagaRogue
             }).Execute());
             
             SceneContext.CameraManager.CameraFollow(minion.transform);
+            yield return SceneContext.Character.transform.DOScale(new Vector3(0.5f,0.5f,0.5f), cameraSpeed);
             yield return StartCoroutine(SceneContext.CameraManager.CameraZoomInOut(3f, cameraSpeed));
             yield return StartCoroutine((new OpenChatEvent().Execute()));
             yield return new ShowMessages(battleOpeningChat, autoSkipTime).Execute();
@@ -45,6 +47,7 @@ namespace GyeMong.GameSystem.Creature.Mob.StateMachineMob.Boss.Summer.NagaRogue
             yield return StartCoroutine( (new SetKeyInputEvent(){_isEnable = false}).Execute());
             yield return StartCoroutine( (new SetKeyInputEvent(){_isEnable = true}).Execute());
             Destroy(minion);
+            SceneContext.Character.transform.localScale = new Vector3(1f, 1f, 1f);
             SceneContext.CameraManager.CameraFollow(SceneContext.Character.transform);
             yield return StartCoroutine(SceneContext.CameraManager.CameraZoomInOut(5f, cameraSpeed));
             StartCoroutine(nagaRogueOpeningEvent.TriggerEvents());

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Mob/StateMachineMob/Minion/ShadowOfHero/ShadowBattleEvent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Mob/StateMachineMob/Minion/ShadowOfHero/ShadowBattleEvent.cs
@@ -12,6 +12,8 @@ namespace GyeMong.GameSystem.Creature.Mob.StateMachineMob.Minion.ShadowOfHero
         [SerializeField] private ShadowOfHero shadow;
         [SerializeField] private Vector3 cameraDestination;
         [SerializeField] private float cameraSpeed;
+        [SerializeField] private float cameraSize;
+        [SerializeField] private float cameraDuration;
         [SerializeField] private List<MultiChatMessageData> beforeScript;
 
         private void OnTriggerEnter2D(Collider2D other)
@@ -25,8 +27,9 @@ namespace GyeMong.GameSystem.Creature.Mob.StateMachineMob.Minion.ShadowOfHero
         private IEnumerator TriggerEvent()
         {
             GetComponent<Collider2D>().enabled = false;
-            yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = false }).Execute());
-            yield return StartCoroutine(SceneContext.CameraManager.CameraMove(cameraDestination, cameraSpeed));
+            yield return (new SetKeyInputEvent() { _isEnable = false }).Execute();
+            yield return SceneContext.CameraManager.CameraMove(cameraDestination, cameraSpeed);
+            yield return SceneContext.CameraManager.CameraZoomInOut(cameraSize, cameraDuration);
             if (beforeScript != null)
             {
                 foreach (var script in beforeScript)

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Mob/StateMachineMob/Minion/ShadowOfHero/ShadowEvent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Mob/StateMachineMob/Minion/ShadowOfHero/ShadowEvent.cs
@@ -37,14 +37,8 @@ namespace GyeMong.GameSystem.Creature.Mob.StateMachineMob.Minion.ShadowOfHero
             yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = false }).Execute());
             
             // 그림자 숲 도착
-            var cameraZoomEvent1 = new CameraZoomInOut();
-            cameraZoomEvent1.SetSize(cameraSize1);
-            cameraZoomEvent1.SetDuration(cameraDuration1);
-            yield return cameraZoomEvent1.Execute();
-            var cameraMoveEvent1 = new CameraMove();
-            cameraMoveEvent1.SetDestination(cameraDestination1);
-            cameraMoveEvent1.SetSpeed(cameraSpeed1);
-            yield return cameraMoveEvent1.Execute();
+            yield return SceneContext.CameraManager.CameraZoomInOut(cameraSize1, cameraDuration1);
+            yield return SceneContext.CameraManager.CameraMove(cameraDestination1, cameraSpeed1);
             yield return StartCoroutine(SceneContext.EffectManager.FadeOut(0f));
             yield return new WaitForSeconds(0.5f);
             StartCoroutine(SceneContext.EffectManager.FadeIn(1f));
@@ -60,10 +54,7 @@ namespace GyeMong.GameSystem.Creature.Mob.StateMachineMob.Minion.ShadowOfHero
             yield return new WaitForSeconds(1f);
             
             // 그림자 발견
-            var cameraMoveEvent2 = new CameraMove();
-            cameraMoveEvent2.SetDestination(cameraDestination2);
-            cameraMoveEvent2.SetSpeed(cameraSpeed2);
-            yield return cameraMoveEvent2.Execute();
+            yield return SceneContext.CameraManager.CameraMove(cameraDestination2, cameraSpeed2);
             yield return (new MoveCreatureEvent()
             {
                 creatureType = MoveCreatureEvent.CreatureType.Selectable,

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Mob/StateMachineMob/Minion/ShadowOfHero/ShadowEvent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Mob/StateMachineMob/Minion/ShadowOfHero/ShadowEvent.cs
@@ -5,12 +5,27 @@ using GyeMong.EventSystem.Event;
 using GyeMong.EventSystem.Event.CinematicEvent;
 using GyeMong.EventSystem.Event.Input;
 using UnityEngine;
+using Visual.Camera;
 
 namespace GyeMong.GameSystem.Creature.Mob.StateMachineMob.Minion.ShadowOfHero
 {
     public class ShadowEvent : MonoBehaviour
     {
         [SerializeField] private ShadowMovementController _shadow;
+
+        [Header("First Event")]
+        [SerializeField] private float cameraSize1;
+        [SerializeField] private float cameraDuration1;
+        [SerializeField] private Vector3 cameraDestination1;
+        [SerializeField] private float cameraSpeed1;
+        [SerializeField] private Vector3 playerDestination1;
+        [SerializeField] private float playerSpeed1;
+        
+        [Header("Second Event")]
+        [SerializeField] private Vector3 cameraDestination2;
+        [SerializeField] private float cameraSpeed2;
+        [SerializeField] private Vector3 shadowDestination2;
+        [SerializeField] private float shadowSpeed2;
 
         private void Start()
         {
@@ -20,14 +35,47 @@ namespace GyeMong.GameSystem.Creature.Mob.StateMachineMob.Minion.ShadowOfHero
         private IEnumerator TriggerEvent()
         {
             yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = false }).Execute());
+            
+            // 그림자 숲 도착
+            var cameraZoomEvent1 = new CameraZoomInOut();
+            cameraZoomEvent1.SetSize(cameraSize1);
+            cameraZoomEvent1.SetDuration(cameraDuration1);
+            yield return cameraZoomEvent1.Execute();
+            var cameraMoveEvent1 = new CameraMove();
+            cameraMoveEvent1.SetDestination(cameraDestination1);
+            cameraMoveEvent1.SetSpeed(cameraSpeed1);
+            yield return cameraMoveEvent1.Execute();
+            yield return StartCoroutine(SceneContext.EffectManager.FadeOut(0f));
+            yield return new WaitForSeconds(0.5f);
+            StartCoroutine(SceneContext.EffectManager.FadeIn(1f));
+            var playerMoveEvent = new MoveCreatureEvent()
+            {
+                creatureType = MoveCreatureEvent.CreatureType.Player,
+                iControllable = null,
+                target = playerDestination1,
+                speed = playerSpeed1
+            };
+            yield return playerMoveEvent.Execute();
+            
+            yield return new WaitForSeconds(1f);
+            
+            // 그림자 발견
+            var cameraMoveEvent2 = new CameraMove();
+            cameraMoveEvent2.SetDestination(cameraDestination2);
+            cameraMoveEvent2.SetSpeed(cameraSpeed2);
+            yield return cameraMoveEvent2.Execute();
             yield return (new MoveCreatureEvent()
             {
                 creatureType = MoveCreatureEvent.CreatureType.Selectable,
                 iControllable = _shadow,
-                speed = 5f,
-                target = new Vector3(57.5299988f,-70.5999985f,0)
+                speed = shadowSpeed2,
+                target = shadowDestination2
             }).Execute();
             yield return (new SetActiveObject() {_gameObject = _shadow.gameObject, isActive = false}).Execute();
+            var playerAnimatorParameter = new SetAnimatorParameter() {_creatureType = SetAnimatorParameter.CreatureType.Player};
+            playerAnimatorParameter.SetParameter("Speed", 10);
+            yield return playerAnimatorParameter.Execute();
+            yield return (new CameraFollowPlayer()).Execute();
             yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = true }).Execute());
         }
     }

--- a/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/GolemEntrance.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/GolemEntrance.cs
@@ -1,3 +1,4 @@
+using System;
 using GyeMong.EventSystem.Event.Boss;
 using GyeMong.EventSystem.Event.CinematicEvent;
 using GyeMong.EventSystem.Event.Input;
@@ -35,7 +36,7 @@ namespace GyeMong.GameSystem.Map.MapEvent
         [SerializeField] private GameObject bossRoomObj1;
         [SerializeField] private GameObject bossRoomObj2;
 
-        [Header("")]
+        [Header("Boss")]
         [SerializeField] private GyeMong.GameSystem.Creature.Mob.StateMachineMob.Boss.Boss boss;
 
         [Header("Start Animator")]
@@ -50,21 +51,15 @@ namespace GyeMong.GameSystem.Map.MapEvent
         [SerializeField] private List<MultiChatMessageData> beforeScript;
 
         private bool _isTriggered = false;
-        private void OnTriggerEnter2D(Collider2D other)
-        {
-            if (other.CompareTag("Player") && !_isTriggered)
-            {
-                StartCoroutine(TriggerEvents());
-            }
-        }
 
-        public IEnumerator Trigger()
+        private void Start()
         {
-            return TriggerEvents();
+            StartCoroutine(TriggerEvents());
         }
 
         private IEnumerator TriggerEvents()
         {
+            yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = false }).Execute());
             _isTriggered = true;
 
             var stopAnimEvent = new CustomStopAnimatorEvent();
@@ -75,8 +70,6 @@ namespace GyeMong.GameSystem.Map.MapEvent
             changeSpriteEvent.SetSpriteRenderer(targetSpriteRenderer);
             changeSpriteEvent.SetSprite(newSprite1);
             yield return changeSpriteEvent.Execute();
-
-            yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = false }).Execute());
 
             var moveEvent = new MoveCreatureEvent();
             moveEvent.creatureType = MoveCreatureEvent.CreatureType.Player;

--- a/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/SpringGardenEvent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/SpringGardenEvent.cs
@@ -54,22 +54,13 @@ namespace GyeMong.GameSystem.Map.MapEvent
             yield return (new SetKeyInputEvent() { _isEnable = false }).Execute();
             
             // 해변 도착
-            var cameraZoomEvent1 = new CameraZoomInOut();
-            cameraZoomEvent1.SetSize(cameraSize1);
-            cameraZoomEvent1.SetDuration(cameraDuration1);
-            yield return cameraZoomEvent1.Execute();
-            var cameraMoveEvent1 = new CameraMove();
-            cameraMoveEvent1.SetDestination(cameraDestination1);
-            cameraMoveEvent1.SetSpeed(cameraSpeed1);
-            yield return cameraMoveEvent1.Execute();
+            yield return SceneContext.CameraManager.CameraZoomInOut(cameraSize1,  cameraDuration1);
+            yield return SceneContext.CameraManager.CameraMove(cameraDestination1, cameraSpeed1);
             yield return StartCoroutine(SceneContext.EffectManager.FadeOut(0f));
             yield return new WaitForSeconds(0.5f);
             yield return StartCoroutine(SceneContext.EffectManager.FadeIn(1f));
             yield return new WaitForSeconds(0.5f);
-            var cameraMoveEvent2 = new CameraMove();
-            cameraMoveEvent2.SetDestination(cameraDestination1_2);
-            cameraMoveEvent2.SetSpeed(cameraSpeed1_2);
-            yield return cameraMoveEvent2.Execute();
+            yield return SceneContext.CameraManager.CameraMove(cameraDestination1_2, cameraSpeed1_2);
             yield return new WaitForSeconds(1f);
             var animParamEvent = new SetAnimatorParameter {_creatureType = SetAnimatorParameter.CreatureType.Player};
             animParamEvent.SetParameter("yDir", 0);
@@ -88,12 +79,9 @@ namespace GyeMong.GameSystem.Map.MapEvent
             
             
             // 꼬마 엘프 조우
-            var cameraMoveEvent = new CameraMove();
             Vector3 cameraDestination = ((SceneContext.Character.transform.position + elfChild.transform.position) / 2);
             cameraDestination.z = -10;
-            cameraMoveEvent.SetDestination(cameraDestination);
-            cameraMoveEvent.SetSpeed(cameraSpeed2);
-            yield return cameraMoveEvent.Execute();
+            yield return SceneContext.CameraManager.CameraMove(cameraDestination, cameraSpeed2);
             if (beforeScript != null)
             {
                 foreach (var script in beforeScript)
@@ -118,10 +106,7 @@ namespace GyeMong.GameSystem.Map.MapEvent
             yield return (new SetKeyInputEvent() { _isEnable = false }).Execute();
             yield return SceneContext.CameraManager.CameraMove(cameraDestination3, cameraSpeed3);
             yield return (new SetActiveObject() {_gameObject = elfChild, isActive = false}).Execute();
-            var cameraZoomEvent3 = new CameraZoomInOut();
-            cameraZoomEvent3.SetSize(cameraSize3);
-            cameraZoomEvent3.SetDuration(cameraDuration3);
-            yield return cameraZoomEvent3.Execute();
+            yield return SceneContext.CameraManager.CameraZoomInOut(cameraSize3, cameraSpeed3);
             yield return slimeEvent.Execute();
             yield return new WaitForSeconds(_delayTime);
             SceneContext.CameraManager.CameraFollow(SceneContext.Character.gameObject.transform);

--- a/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/SpringGardenEvent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/SpringGardenEvent.cs
@@ -55,6 +55,9 @@ namespace GyeMong.GameSystem.Map.MapEvent
             cameraMoveEvent1.SetDestination(cameraDestination1);
             cameraMoveEvent1.SetSpeed(cameraSpeed1);
             yield return cameraMoveEvent1.Execute();
+            yield return StartCoroutine(SceneContext.EffectManager.FadeOut(0f));
+            yield return new WaitForSeconds(0.5f);
+            yield return StartCoroutine(SceneContext.EffectManager.FadeIn(1f));
             yield return new WaitForSeconds(0.5f);
             var cameraMoveEvent2 = new CameraMove();
             cameraMoveEvent2.SetDestination(cameraDestination1_2);

--- a/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/SpringGardenEvent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/SpringGardenEvent.cs
@@ -14,21 +14,28 @@ namespace GyeMong.GameSystem.Map.MapEvent
         [SerializeField] private GameObject targetSlime;
         [SerializeField] private GameObject[] slimes;
 
+        [Header("First Event")]
         [SerializeField] private float cameraSize1;
         [SerializeField] private float cameraDuration1;
         [SerializeField] private Vector3 cameraDestination1;
         [SerializeField] private float cameraSpeed1;
         [SerializeField] private Vector3 cameraDestination1_2;
         [SerializeField] private float cameraSpeed1_2;
+        
+        [Header("Second Event")]
         [SerializeField] private float cameraSpeed2;
+        
+        [Header("Third Event")]
         [SerializeField] private Vector3 cameraDestination3;
         [SerializeField] private float cameraSpeed3;
         [SerializeField] private float cameraSize3;
         [SerializeField] private float cameraDuration3;
+        
+        [Header("Elf Event")]
         [SerializeField] private List<MultiChatMessageData> beforeScript;
         [SerializeField] private GameObject elfChild;
+        
         private float _delayTime = 1f;
-
         private bool _isTutorial;
 
         private void Start()

--- a/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/SpringGardenEvent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Map/MapEvent/SpringGardenEvent.cs
@@ -14,8 +14,17 @@ namespace GyeMong.GameSystem.Map.MapEvent
         [SerializeField] private GameObject targetSlime;
         [SerializeField] private GameObject[] slimes;
 
-        [SerializeField] private Vector3 cameraDestination;
-        [SerializeField] private float cameraSpeed;
+        [SerializeField] private float cameraSize1;
+        [SerializeField] private float cameraDuration1;
+        [SerializeField] private Vector3 cameraDestination1;
+        [SerializeField] private float cameraSpeed1;
+        [SerializeField] private Vector3 cameraDestination1_2;
+        [SerializeField] private float cameraSpeed1_2;
+        [SerializeField] private float cameraSpeed2;
+        [SerializeField] private Vector3 cameraDestination3;
+        [SerializeField] private float cameraSpeed3;
+        [SerializeField] private float cameraSize3;
+        [SerializeField] private float cameraDuration3;
         [SerializeField] private List<MultiChatMessageData> beforeScript;
         [SerializeField] private GameObject elfChild;
         private float _delayTime = 1f;
@@ -35,9 +44,23 @@ namespace GyeMong.GameSystem.Map.MapEvent
 
         private IEnumerator TriggerEvents()
         {
-            yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = false }).Execute());
-            yield return new WaitForSeconds(1f);
+            yield return (new SetKeyInputEvent() { _isEnable = false }).Execute();
             
+            // 해변 도착
+            var cameraZoomEvent1 = new CameraZoomInOut();
+            cameraZoomEvent1.SetSize(cameraSize1);
+            cameraZoomEvent1.SetDuration(cameraDuration1);
+            yield return cameraZoomEvent1.Execute();
+            var cameraMoveEvent1 = new CameraMove();
+            cameraMoveEvent1.SetDestination(cameraDestination1);
+            cameraMoveEvent1.SetSpeed(cameraSpeed1);
+            yield return cameraMoveEvent1.Execute();
+            yield return new WaitForSeconds(0.5f);
+            var cameraMoveEvent2 = new CameraMove();
+            cameraMoveEvent2.SetDestination(cameraDestination1_2);
+            cameraMoveEvent2.SetSpeed(cameraSpeed1_2);
+            yield return cameraMoveEvent2.Execute();
+            yield return new WaitForSeconds(1f);
             var animParamEvent = new SetAnimatorParameter {_creatureType = SetAnimatorParameter.CreatureType.Player};
             animParamEvent.SetParameter("yDir", 0);
             animParamEvent.SetParameter("xDir", -1);
@@ -51,9 +74,16 @@ namespace GyeMong.GameSystem.Map.MapEvent
             yield return new WaitForSeconds(0.4f);
             animParamEvent.SetParameter("xDir", 1);
             yield return animParamEvent.Execute();
-
             yield return new WaitForSeconds(1f);
             
+            
+            // 꼬마 엘프 조우
+            var cameraMoveEvent = new CameraMove();
+            Vector3 cameraDestination = ((SceneContext.Character.transform.position + elfChild.transform.position) / 2);
+            cameraDestination.z = -10;
+            cameraMoveEvent.SetDestination(cameraDestination);
+            cameraMoveEvent.SetSpeed(cameraSpeed2);
+            yield return cameraMoveEvent.Execute();
             if (beforeScript != null)
             {
                 foreach (var script in beforeScript)
@@ -64,23 +94,28 @@ namespace GyeMong.GameSystem.Map.MapEvent
             
             if (_isTutorial)
             {
-                yield return StartCoroutine((new SkippablePopupWindowEvent()
-                    { Title = "플레이어 이동", Message = "W, A, S, D를 눌러서 이동할 수 있다.", Duration = 3f }).Execute());
-                yield return StartCoroutine((new SkippablePopupWindowEvent()
-                    { Title = "돌진", Message = "좌측 Shift키를 눌러 돌진할 수 있다.", Duration = 3f }).Execute());
-                yield return StartCoroutine((new SkippablePopupWindowEvent()
-                    { Title = "기본공격", Message = "마우스 좌클릭을 통해 공격할 수 있다.", Duration = 3f }).Execute());
+                yield return (new SkippablePopupWindowEvent()
+                    { Title = "플레이어 이동", Message = "W, A, S, D를 눌러서 이동할 수 있다.", Duration = 3f }).Execute();
+                yield return (new SkippablePopupWindowEvent()
+                    { Title = "돌진", Message = "좌측 Shift키를 눌러 돌진할 수 있다.", Duration = 3f }).Execute();
+                yield return (new SkippablePopupWindowEvent()
+                    { Title = "기본공격", Message = "마우스 좌클릭을 통해 공격할 수 있다.", Duration = 3f }).Execute();
             }
-
+            
+            // 슬라임 전투 이벤트
             SlimeEvents slimeEvent = new SlimeEvents(targetSlime, slimes);
             
-            yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = false }).Execute());
-            yield return StartCoroutine(SceneContext.CameraManager.CameraMove(cameraDestination, cameraSpeed));            
-            yield return StartCoroutine(slimeEvent.Execute());
-            yield return new WaitForSeconds(_delayTime);
+            yield return (new SetKeyInputEvent() { _isEnable = false }).Execute();
+            yield return SceneContext.CameraManager.CameraMove(cameraDestination3, cameraSpeed3);
             yield return (new SetActiveObject() {_gameObject = elfChild, isActive = false}).Execute();
+            var cameraZoomEvent3 = new CameraZoomInOut();
+            cameraZoomEvent3.SetSize(cameraSize3);
+            cameraZoomEvent3.SetDuration(cameraDuration3);
+            yield return cameraZoomEvent3.Execute();
+            yield return slimeEvent.Execute();
+            yield return new WaitForSeconds(_delayTime);
             SceneContext.CameraManager.CameraFollow(SceneContext.Character.gameObject.transform);
-            yield return StartCoroutine((new SetKeyInputEvent() { _isEnable = true }).Execute());
+            yield return (new SetKeyInputEvent() { _isEnable = true }).Execute();
         }
     }
 }


### PR DESCRIPTION
closed #408 

### 설명
각 전투가 벌어지기 전 실행되는 이벤트 연출의 고도화.
  - 
- 해변 : 플레이어가 해변에 도착, 꼬마 엘프 조우, 전투 각 부분별로 카메라 이동/줌 조정
- 그림자 숲 : 그림자 숲 도착, 그림자 보스 조우(그림자 이동), 전투 각 부분별로 카메라 이동/줌 조정
- 골렘 : 이벤트 자동 시작으로 변경 (전투방이 너무 넓어서 왼/오른쪽 벽에 붙어서 시작하면 하루종일 걸어감)
- 나가 도적 : 절벽위에 몹들이 있는 연출의 어색함 개선 (높이 차이가 보이게, 플레이어를 바라보는 이미지로 수정)

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
