### PR TITLE
Feat/412

### DIFF
--- a/Assets/Resources/ScriptableObjects/Creature/Player/PlayerStatData.asset
+++ b/Assets/Resources/ScriptableObjects/Creature/Player/PlayerStatData.asset
@@ -30,16 +30,18 @@ MonoBehaviour:
   - statType: 8
     value: 4
   - statType: 9
-    value: 10
+    value: 15
   - statType: 10
     value: 10
   - statType: 11
-    value: 0.1
+    value: 10
   - statType: 12
-    value: 2
+    value: 0.1
   - statType: 13
-    value: 1
+    value: 2
   - statType: 14
-    value: 0.2
+    value: 1
   - statType: 15
+    value: 0.2
+  - statType: 16
     value: 1

--- a/Assets/Resources/ScriptableObjects/Creature/Player/PlayerStatData.asset
+++ b/Assets/Resources/ScriptableObjects/Creature/Player/PlayerStatData.asset
@@ -36,7 +36,7 @@ MonoBehaviour:
   - statType: 11
     value: 10
   - statType: 12
-    value: 0.1
+    value: 0.4
   - statType: 13
     value: 2
   - statType: 14

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Player/Component/StatComponent.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Player/Component/StatComponent.cs
@@ -15,6 +15,7 @@ namespace GyeMong.GameSystem.Creature.Player.Component
         GRAZE_GAIN_ON_GRAZE,
         GRAZE_GAIN_ON_ATTACK,
         MOVE_SPEED,
+        MOVE_ACCELERATION,
         DASH_SPEED,
         SKILL_SPEED,
         DASH_DURATION,
@@ -133,6 +134,7 @@ namespace GyeMong.GameSystem.Creature.Player.Component
         public float GrazeGainOnGraze => GetStatValue(StatType.GRAZE_GAIN_ON_GRAZE);
         public float GrazeGainOnAttack => GetStatValue(StatType.GRAZE_GAIN_ON_ATTACK);
         public float MoveSpeed => GetStatValue(StatType.MOVE_SPEED);
+        public float MoveAcceleration => GetStatValue(StatType.MOVE_ACCELERATION);
         public float DashSpeed  => GetStatValue(StatType.DASH_SPEED);
         public float SkillSpeed  => GetStatValue(StatType.SKILL_SPEED);
         public float DashDuration => GetStatValue(StatType.DASH_DURATION);
@@ -151,6 +153,7 @@ namespace GyeMong.GameSystem.Creature.Player.Component
             statEntries.Add(new StatEntry(StatType.GRAZE_GAIN_ON_GRAZE, new Stat()));
             statEntries.Add(new StatEntry(StatType.GRAZE_GAIN_ON_ATTACK, new Stat()));
             statEntries.Add(new StatEntry(StatType.MOVE_SPEED, new Stat()));
+            statEntries.Add(new StatEntry(StatType.MOVE_ACCELERATION, new Stat()));
             statEntries.Add(new StatEntry(StatType.DASH_SPEED, new Stat()));
             statEntries.Add(new StatEntry(StatType.SKILL_SPEED, new Stat()));
             statEntries.Add(new StatEntry(StatType.DASH_DURATION, new Stat()));

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Player/PlayerCharacter.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Player/PlayerCharacter.cs
@@ -146,7 +146,11 @@ namespace GyeMong.GameSystem.Creature.Player
         private void MoveCharacter()
         {
             soundController.SetRun(isMoving);
-            playerRb.velocity = movement * stat.MoveSpeed;
+            
+            Vector2 currentVelocity = playerRb.velocity;
+            currentVelocity = Vector2.Lerp(currentVelocity, movement * stat.MoveSpeed, stat.MoveAcceleration * Time.fixedDeltaTime);
+
+            playerRb.velocity = currentVelocity;
         }
 
         private void UpdateState()

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Player/PlayerCharacter.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Player/PlayerCharacter.cs
@@ -77,9 +77,9 @@ namespace GyeMong.GameSystem.Creature.Player
                 if (canMove)
                 {
                     HandleMoveInput();
+                    UpdateState();
                 }
                 HandleActionInput();
-                UpdateState();
             }
         }
 
@@ -261,7 +261,9 @@ namespace GyeMong.GameSystem.Creature.Player
             animator.SetBool("isDashing", true);
             soundController.Trigger(PlayerSoundType.DASH);
 
-            Vector2 dashDirection = GetCurrentInputDirection(lastMovementDirection.normalized);
+            Vector2 dashDirection = GetCurrentInputDirection(mouseDirection);
+            animator.SetFloat("xDir", dashDirection.x);
+            animator.SetFloat("yDir", dashDirection.y);
             Vector2 startPosition = playerRb.position;
 
             RaycastHit2D hit = Physics2D.Raycast(startPosition, dashDirection, stat.DashDistance,
@@ -270,14 +272,9 @@ namespace GyeMong.GameSystem.Creature.Player
                 ? startPosition + dashDirection * stat.DashDistance
                 : hit.point + hit.normal * 0.1f;
 
-            float elapsedTime = 0f;
-
-            while (elapsedTime < stat.DashDuration)
-            {
-                elapsedTime += Time.deltaTime;
-                playerRb.MovePosition(Vector2.Lerp(startPosition, targetPosition, elapsedTime / stat.DashDuration));
-                yield return null;
-            }
+            yield return playerRb.DOMove(targetPosition, stat.DashDuration)
+                .SetEase(Ease.InOutQuad)
+                .WaitForCompletion();
 
             StopPlayer();
 

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Player/PlayerCharacter.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Player/PlayerCharacter.cs
@@ -312,7 +312,7 @@ namespace GyeMong.GameSystem.Creature.Player
             if (InputManager.Instance.GetKey(ActionCode.MoveRight)) dir += Vector2.right;
             if (InputManager.Instance.GetKey(ActionCode.MoveLeft)) dir += Vector2.left;
 
-            if (dir != Vector2.zero) return dir;
+            if (dir != Vector2.zero) return dir.normalized;
             return direction;
         }
 
@@ -337,6 +337,7 @@ namespace GyeMong.GameSystem.Creature.Player
             if (comboQueued)
             {
                 comboQueued = false;
+                UpdateState();
                 soundController.Trigger(PlayerSoundType.SWORD_SWING);
                 animator.SetBool("isAttacking2", true);
                 SpawnAttackCollider(attackComboColliderPrefab);
@@ -349,6 +350,8 @@ namespace GyeMong.GameSystem.Creature.Player
             canMove = true;
             animator.SetBool("isAttacking", false);
             isAttacking = false;
+            
+            yield return null;
         }
 
         private void AttackMove(Vector2 direction)

--- a/Assets/Scripts/GyeMong/GameSystem/Creature/Player/PlayerCharacter.cs
+++ b/Assets/Scripts/GyeMong/GameSystem/Creature/Player/PlayerCharacter.cs
@@ -273,7 +273,7 @@ namespace GyeMong.GameSystem.Creature.Player
                 : hit.point + hit.normal * 0.1f;
 
             yield return playerRb.DOMove(targetPosition, stat.DashDuration)
-                .SetEase(Ease.InOutQuad)
+                .SetEase(Ease.OutCubic)
                 .WaitForCompletion();
 
             StopPlayer();


### PR DESCRIPTION
closed #412 

### 설명
플레이어의 이동과 공격을 보다 현실적이고 부드럽게 개선
- 
- 상하좌우 키 입력 시, 즉시 최고 속도로 움직이는 대신 점진적으로 가속되는 움직임 적용
- 대시 속도를 조정하고, 가속 곡선을 적용하여 초중반은 가속을 받아 빠르게 -> 후반에 느려지는 속도 변화 구현
  - 대쉬 시 마우스 방향을 바라보는게 아닌, 대쉬 방향으로 플레이어의 방향이 돌아가게 변경
  - 방향키를 누르지 않고 대쉬 시, 마우스 방향으로 대쉬하도록 변경
  - 다른 행동 중 대쉬를 쓰더라도 대쉬를 우선행동으로 부드럽게 실행
- 공격 시 이동이 가속을 반영하도록 변경
- 마우스 클릭을 누르고 있는 동안 연속 공격이 가능하도록 개선

### 체크리스트
- [x] 코드가 잘 작동하는지 로컬에서 테스트했나요?
- [x] 기존 기능에 대한 테스트가 모두 통과했나요?
- [x] 코드 컨벤션이 일관된지 확인했습니까?
