### PR TITLE
Clean up TemplateData before deployment

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,7 @@ jobs:
           cd GyeMong_Play
 
           # copy build result
+          rm -rf ./TemplateData
           rm -rf ./Build
           rm -rf ./index.html
           cp -r ../build/WebGL/WebGL/* ./


### PR DESCRIPTION
Remove TemplateData directory before copying build results.

### 설명
- ci/cd에서 push 에러를 고쳤습니다.
