### PR TITLE
ci: 릴리스 시 맥/윈도우/웹 빌드 생성 및 링크 연결

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,18 +4,44 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  UNITY_VERSION: 2022.3.34f1
+  BUILD_NAME: GyeMong
 
 jobs:
-  buildWebGL:
+  build:
+    name: Build WebGL
     runs-on: ubuntu-latest
     steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           submodules: 'recursive'
           token: ${{ secrets.GYE_MONG_PLAY_TOKEN }}
           fetch-depth: 0
-      
+
       - name: Cache Library folder (WebGL)
         uses: actions/cache@v4
         with:
@@ -33,35 +59,41 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
         with:
-          unityVersion: 2022.3.22f1
+          unityVersion: ${{ env.UNITY_VERSION }}
           targetPlatform: WebGL
+          buildName: ${{ env.BUILD_NAME }}
+          buildsPath: build
           customParameters: -logFile - -ignoreCompilerErrors
 
-      - name: Upload WebGL build artifact
+      - name: Upload WebGL build
         uses: actions/upload-artifact@v4
         with:
-          name: WebGL-Build
-          path: build
+          name: webgl-build
+          path: build/WebGL/${{ env.BUILD_NAME }}
+          retention-days: 7
 
-      - name: Push to another repo
-        run: |
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+  deploy:
+    name: Deploy to GitHub Pages
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download WebGL build
+        uses: actions/download-artifact@v4
+        with:
+          name: webgl-build
+          path: ./webgl-build
 
-          # clone target repo
-          git clone https://x-access-token:${{ secrets.GYE_MONG_PLAY_TOKEN }}@github.com/Apptive-Game-Team/GyeMong_Play.git
-          
-          ls -R build
-          
-          cd GyeMong_Play
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
 
-          # copy build result
-          rm -rf ./Build
-          rm -rf ./index.html
-          cp -r ../build/WebGL/WebGL/* ./
-          
-          ls -R 
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./webgl-build
 
-          git add .
-          git commit -m "Update WebGL build from main repo"
-          git push origin main
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,8 +20,6 @@ concurrency:
 env:
   UNITY_VERSION: 2022.3.34f1
   BUILD_NAME: GyeMong
-  # 배포된 WebGL 을 플레이할 수 있는 주소. 다르면 저장소 Variables 에 WEB_PLAY_URL 을 등록하세요.
-  DEFAULT_WEB_PLAY_URL: https://apptive-game-team.github.io/GyeMong_Play/
 
 jobs:
   prepare:
@@ -130,11 +128,9 @@ jobs:
         run: gh release upload "$TAG" "$ARCHIVE" --clobber
 
   webgl:
-    name: Build & deploy WebGL
+    name: Build WebGL
     needs: prepare
     runs-on: ubuntu-latest
-    outputs:
-      play_url: ${{ steps.play.outputs.url }}
     steps:
       - name: Free disk space
         uses: jlumbroso/free-disk-space@v1.3.1
@@ -196,39 +192,51 @@ jobs:
           ARCHIVE: ${{ steps.package.outputs.archive }}
         run: gh release upload "$TAG" "$ARCHIVE" --clobber
 
-      - name: Publish WebGL to GyeMong_Play
-        env:
-          TAG: ${{ needs.prepare.outputs.tag }}
-          PLAY_TOKEN: ${{ secrets.GYE_MONG_PLAY_TOKEN }}
-        run: |
-          set -euo pipefail
-          git config --global user.name "github-actions[bot]"
-          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - name: Upload WebGL build for Pages
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-webgl
+          path: build/WebGL/${{ env.BUILD_NAME }}
+          retention-days: 7
 
-          git clone "https://x-access-token:$PLAY_TOKEN@github.com/Apptive-Game-Team/GyeMong_Play.git" play-repo
-          cd play-repo
+  deploy-pages:
+    name: Deploy WebGL to GitHub Pages
+    needs: webgl
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    concurrency:
+      group: "pages"
+      cancel-in-progress: false
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    outputs:
+      play_url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Download WebGL build
+        uses: actions/download-artifact@v4
+        with:
+          name: release-webgl
+          path: ./webgl-build
 
-          # 기존 빌드 산출물 제거 후 새 빌드 복사 (.git 은 유지)
-          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
-          cp -r "$GITHUB_WORKSPACE/build/WebGL/$BUILD_NAME/." ./
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
 
-          git add -A
-          if git diff --cached --quiet; then
-            echo "변경 사항이 없어 푸시를 건너뜁니다."
-          else
-            git commit -m "Update WebGL build for $TAG"
-            git push origin HEAD:main
-          fi
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./webgl-build
 
-      - name: Resolve play URL
-        id: play
-        env:
-          WEB_PLAY_URL: ${{ vars.WEB_PLAY_URL }}
-        run: echo "url=${WEB_PLAY_URL:-$DEFAULT_WEB_PLAY_URL}" >> "$GITHUB_OUTPUT"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4
 
   links:
     name: Link builds on release
-    needs: [prepare, desktop, webgl]
+    needs: [prepare, desktop, webgl, deploy-pages]
     if: always() && needs.prepare.result == 'success'
     runs-on: ubuntu-latest
     steps:
@@ -237,7 +245,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
           TAG: ${{ needs.prepare.outputs.tag }}
-          PLAY_URL: ${{ needs.webgl.outputs.play_url }}
+          PLAY_URL: ${{ needs.deploy-pages.outputs.play_url }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
           set -euo pipefail

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,289 @@
+name: Release Build
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag to build (e.g. v1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+concurrency:
+  group: release-${{ github.event.release.tag_name || inputs.tag }}
+  cancel-in-progress: false
+
+env:
+  UNITY_VERSION: 2022.3.34f1
+  BUILD_NAME: GyeMong
+  # 배포된 WebGL 을 플레이할 수 있는 주소. 다르면 저장소 Variables 에 WEB_PLAY_URL 을 등록하세요.
+  DEFAULT_WEB_PLAY_URL: https://apptive-game-team.github.io/GyeMong_Play/
+
+jobs:
+  prepare:
+    name: Prepare release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.resolve.outputs.tag }}
+    steps:
+      - name: Resolve tag and ensure release exists
+        id: resolve
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          EVENT_TAG: ${{ github.event.release.tag_name }}
+          INPUT_TAG: ${{ inputs.tag }}
+        run: |
+          set -euo pipefail
+          TAG="${EVENT_TAG:-$INPUT_TAG}"
+          if [ -z "$TAG" ]; then
+            echo "::error::릴리스 태그를 확인할 수 없습니다."
+            exit 1
+          fi
+          if ! gh release view "$TAG" >/dev/null 2>&1; then
+            echo "릴리스가 없어 새로 만듭니다: $TAG"
+            gh release create "$TAG" --title "$TAG" --target "$GITHUB_SHA" --generate-notes
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+  desktop:
+    name: Build ${{ matrix.label }}
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - targetPlatform: StandaloneOSX
+            label: macOS
+          - targetPlatform: StandaloneWindows64
+            label: Windows
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          token: ${{ secrets.GYE_MONG_PLAY_TOKEN }}
+          fetch-depth: 0
+
+      - name: Cache Library folder
+        uses: actions/cache@v4
+        with:
+          path: |
+            Library/ShaderCache
+            Library/ScriptAssemblies
+          key: ${{ matrix.targetPlatform }}-Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            ${{ matrix.targetPlatform }}-Library-
+
+      - name: Build ${{ matrix.label }}
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          unityVersion: ${{ env.UNITY_VERSION }}
+          targetPlatform: ${{ matrix.targetPlatform }}
+          buildName: ${{ env.BUILD_NAME }}
+          buildsPath: build
+          customParameters: -logFile - -ignoreCompilerErrors
+
+      - name: Package build
+        id: package
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          TARGET: ${{ matrix.targetPlatform }}
+          LABEL: ${{ matrix.label }}
+        run: |
+          set -euo pipefail
+          sudo chown -R "$(id -u):$(id -g)" build
+          if [ "$TARGET" = "StandaloneOSX" ]; then
+            # .app 번들의 실행 권한이 유지되도록 보정
+            chmod -R +x "build/$TARGET/$BUILD_NAME.app/Contents/MacOS" || true
+          fi
+          ARCHIVE="$BUILD_NAME-$TAG-$LABEL.zip"
+          (cd "build/$TARGET" && zip -r -y -q "$GITHUB_WORKSPACE/$ARCHIVE" .)
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload build to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          ARCHIVE: ${{ steps.package.outputs.archive }}
+        run: gh release upload "$TAG" "$ARCHIVE" --clobber
+
+  webgl:
+    name: Build & deploy WebGL
+    needs: prepare
+    runs-on: ubuntu-latest
+    outputs:
+      play_url: ${{ steps.play.outputs.url }}
+    steps:
+      - name: Free disk space
+        uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: 'recursive'
+          token: ${{ secrets.GYE_MONG_PLAY_TOKEN }}
+          fetch-depth: 0
+
+      - name: Cache Library folder (WebGL)
+        uses: actions/cache@v4
+        with:
+          path: |
+            Library/ShaderCache
+            Library/ScriptAssemblies
+          key: WebGL-Library-${{ hashFiles('Assets/**', 'Packages/**', 'ProjectSettings/**') }}
+          restore-keys: |
+            WebGL-Library-
+
+      - name: Build WebGL
+        uses: game-ci/unity-builder@v4
+        env:
+          UNITY_LICENSE: ${{ secrets.UNITY_LICENSE }}
+          UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
+          UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
+        with:
+          unityVersion: ${{ env.UNITY_VERSION }}
+          targetPlatform: WebGL
+          buildName: ${{ env.BUILD_NAME }}
+          buildsPath: build
+          customParameters: -logFile - -ignoreCompilerErrors
+
+      - name: Package WebGL build
+        id: package
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          set -euo pipefail
+          sudo chown -R "$(id -u):$(id -g)" build
+          ARCHIVE="$BUILD_NAME-$TAG-WebGL.zip"
+          (cd "build/WebGL/$BUILD_NAME" && zip -r -y -q "$GITHUB_WORKSPACE/$ARCHIVE" .)
+          echo "archive=$ARCHIVE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload WebGL build to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          ARCHIVE: ${{ steps.package.outputs.archive }}
+        run: gh release upload "$TAG" "$ARCHIVE" --clobber
+
+      - name: Publish WebGL to GyeMong_Play
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+          PLAY_TOKEN: ${{ secrets.GYE_MONG_PLAY_TOKEN }}
+        run: |
+          set -euo pipefail
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+
+          git clone "https://x-access-token:$PLAY_TOKEN@github.com/Apptive-Game-Team/GyeMong_Play.git" play-repo
+          cd play-repo
+
+          # 기존 빌드 산출물 제거 후 새 빌드 복사 (.git 은 유지)
+          find . -mindepth 1 -maxdepth 1 ! -name '.git' -exec rm -rf {} +
+          cp -r "$GITHUB_WORKSPACE/build/WebGL/$BUILD_NAME/." ./
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "변경 사항이 없어 푸시를 건너뜁니다."
+          else
+            git commit -m "Update WebGL build for $TAG"
+            git push origin HEAD:main
+          fi
+
+      - name: Resolve play URL
+        id: play
+        env:
+          WEB_PLAY_URL: ${{ vars.WEB_PLAY_URL }}
+        run: echo "url=${WEB_PLAY_URL:-$DEFAULT_WEB_PLAY_URL}" >> "$GITHUB_OUTPUT"
+
+  links:
+    name: Link builds on release
+    needs: [prepare, desktop, webgl]
+    if: always() && needs.prepare.result == 'success'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update release notes with download links
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TAG: ${{ needs.prepare.outputs.tag }}
+          PLAY_URL: ${{ needs.webgl.outputs.play_url }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+
+          asset_url() {
+            # 릴리스에 실제로 올라간 에셋만 링크로 노출
+            name=$(gh release view "$TAG" --json assets -q ".assets[].name | select(endswith(\"$1\"))" | head -n 1)
+            if [ -n "$name" ]; then
+              printf '[%s](%s/%s/releases/download/%s/%s)' \
+                "$name" "$GITHUB_SERVER_URL" "$GITHUB_REPOSITORY" "$TAG" "$name"
+            fi
+          }
+
+          MAC=$(asset_url "-macOS.zip")
+          WIN=$(asset_url "-Windows.zip")
+          WEB=$(asset_url "-WebGL.zip")
+          FAILED="빌드 실패 — [로그 보기]($RUN_URL)"
+
+          {
+            echo '<!-- release-links:start -->'
+            echo '## 📦 다운로드'
+            echo
+            echo '| 플랫폼 | 링크 |'
+            echo '| --- | --- |'
+            echo "| 🍎 macOS | ${MAC:-$FAILED} |"
+            echo "| 🪟 Windows | ${WIN:-$FAILED} |"
+            if [ -n "$PLAY_URL" ]; then
+              echo "| 🌐 웹에서 바로 플레이 | [$PLAY_URL]($PLAY_URL) |"
+            else
+              echo "| 🌐 웹에서 바로 플레이 | $FAILED |"
+            fi
+            echo "| 🌐 웹 빌드 (직접 호스팅용) | ${WEB:-$FAILED} |"
+            echo
+            echo '> macOS 빌드는 코드 서명이 되어 있지 않습니다. 실행이 막히면 압축을 푼 뒤'
+            echo '> `xattr -dr com.apple.quarantine '"$BUILD_NAME"'.app` 을 실행해 주세요.'
+            echo '<!-- release-links:end -->'
+          } > links.md
+
+          gh release view "$TAG" --json body -q .body > body.md
+
+          # 이전에 추가된 링크 블록이 있으면 교체
+          awk '
+            $0 == "<!-- release-links:start -->" { skip = 1 }
+            !skip { print }
+            $0 == "<!-- release-links:end -->" { skip = 0 }
+          ' body.md > body-clean.md
+
+          { cat body-clean.md; echo; cat links.md; } > new-body.md
+          gh release edit "$TAG" --notes-file new-body.md


### PR DESCRIPTION
## 요약

릴리스를 publish 하면 macOS / Windows / WebGL 을 모두 빌드해서, 릴리스 본문에 플랫폼별 다운로드·플레이 링크를 자동으로 붙여주는 워크플로우를 추가합니다. 기존 WebGL 배포도 `GyeMong_Play` 저장소 푸시 대신 이 저장소의 GitHub Pages 를 쓰도록 옮겼습니다.

## 변경 사항

### `.github/workflows/release.yml` (신규)

릴리스 publish 시 자동 실행, `workflow_dispatch`(태그 입력)로 수동 실행도 가능합니다.

| Job | 하는 일 |
| --- | --- |
| `prepare` | 태그 확인, 릴리스가 없으면 생성 |
| `desktop` | matrix 로 `StandaloneOSX` / `StandaloneWindows64` 병렬 빌드 → zip → 릴리스 에셋 업로드 |
| `webgl` | WebGL 빌드 → zip 을 릴리스 에셋으로 업로드 |
| `deploy-pages` | WebGL 을 GitHub Pages 로 배포 |
| `links` | 릴리스 본문에 다운로드 표 추가 |

- 에셋 이름은 `GyeMong-<태그>-macOS.zip` 형식입니다.
- `links` 는 릴리스에 실제로 올라간 에셋만 링크하고, 실패한 플랫폼은 "빌드 실패 — 로그 보기" 로 표시합니다.
- 링크 표를 HTML 마커로 감싸서 재실행해도 중복되지 않고 교체됩니다.
- macOS 빌드는 서명이 없어 `xattr -dr com.apple.quarantine` 안내 문구를 함께 넣습니다.
- 플레이 링크는 `deploy-pages` 가 반환한 실제 Pages 주소를 사용합니다(하드코딩 없음).

### `.github/workflows/deploy.yml` (수정)

- `GyeMong_Play` 저장소를 clone 해서 푸시하던 방식을 제거하고 `actions/deploy-pages` 로 교체
- `release.yml` 과 같은 `pages` concurrency 그룹을 사용해 배포가 겹치지 않게 처리
- Unity 버전을 프로젝트와 동일한 `2022.3.34f1` 로 정정 (기존 `2022.3.22f1`)
- 디스크 정리 스텝과 `workflow_dispatch` 추가

## 머지 후 필요한 설정

- Settings → Pages → **Source: GitHub Actions** 로 켜야 합니다. 켜면 `https://apptive-game-team.github.io/GyeMong/` 이 됩니다.
- 시크릿은 `UNITY_LICENSE`, `UNITY_EMAIL`, `UNITY_PASSWORD`, `GYE_MONG_PLAY_TOKEN` 을 그대로 사용합니다. 다만 `GYE_MONG_PLAY_TOKEN` 은 이제 `GyeMong_Play` 푸시용이 아니라 프라이빗 서브모듈 `GyeMong_Art` 체크아웃 용도로만 쓰입니다.

## 참고

Linux 러너에서 빌드하므로 스크립팅 백엔드는 Mono 입니다. IL2CPP 가 필요하면 해당 플랫폼 러너로 옮겨야 합니다. main 푸시가 Pages 를 최신 개발 빌드로 덮으므로, 버전 고정이 필요하면 릴리스에 함께 올라가는 `GyeMong-<태그>-WebGL.zip` 을 사용하면 됩니다.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MyYXpcKjZxYDEvkXyriKEV)_